### PR TITLE
refactor: wrap error for nft ctrt issue

### DIFF
--- a/vsys/ctrt_nft_ctrt.go
+++ b/vsys/ctrt_nft_ctrt.go
@@ -82,5 +82,10 @@ func (n *NFTCtrt) Issue(by *Account, tokenDescription, attachment string) (*Broa
 		FEE_EXEC_CTRT,
 	)
 
-	return by.ExecuteCtrt(txReq)
+	resp, err := by.ExecuteCtrt(txReq)
+	if err != nil {
+		return nil, fmt.Errorf("Issue: %w", err)
+	}
+
+	return resp, nil
 }


### PR DESCRIPTION
## What Does This PR Do
Wrap the error returned by the `Issue` method of nft contract.

## How Are The Changes Tested
Manually tested locally.