### PR TITLE
fix: revert constructor of CtrtMeta to original state

### DIFF
--- a/vsys/api_tx.go
+++ b/vsys/api_tx.go
@@ -145,7 +145,6 @@ func (r *ReleaseSlotsTxInfoResp) GetTxGeneral() TxGeneral {
 
 type RegCtrtTxInfoResp struct {
 	TxGeneral
-
 	CtrtId      Str          `json:"contractId"`
 	Ctrt        CtrtMetaJSON `json:"contract"`
 	InitData    Str          `json:"initData"`

--- a/vsys/model_ctrt_meta.go
+++ b/vsys/model_ctrt_meta.go
@@ -608,8 +608,11 @@ func (c *CtrtMeta) Serialize() Bytes {
 		c.Triggers.Size() +
 		c.Descriptors.Size() +
 		c.StateVars.Size() +
-		c.StateMap.Size() +
 		c.Textual.Size()
+
+	if c.LangVer != 1 {
+		size += c.StateMap.Size()
+	}
 
 	b := make([]byte, 0, size)
 

--- a/vsys/model_ctrt_meta.go
+++ b/vsys/model_ctrt_meta.go
@@ -330,6 +330,53 @@ type CtrtMetaJSON struct {
 	Textual *CtrtMetaTextualJSON `json:"textual"`
 }
 
+func (c *CtrtMetaJSON) GetCtrtMeta() (*CtrtMeta, error) {
+	cm := &c.CtrtMeta
+	l := 3
+	if c.LangVer == 2 {
+		l++
+	}
+	b := PackUInt16(uint16(l))
+
+	var err error
+	bytes, err := B58Decode(c.Textual.Triggers)
+	if err != nil {
+		return nil, err
+	}
+	litem := PackUInt16(uint16(len(bytes)))
+	b = append(b, litem...)
+	b = append(b, bytes...)
+	bytes, err = B58Decode(c.Textual.Descriptors)
+	if err != nil {
+		return nil, err
+	}
+	litem = PackUInt16(uint16(len(bytes)))
+	b = append(b, litem...)
+	b = append(b, bytes...)
+	if err != nil {
+		return nil, err
+	}
+	litem = PackUInt16(uint16(len(bytes)))
+	b = append(b, litem...)
+	b = append(b, bytes...)
+	if c.LangVer == 2 {
+		bytes, err = B58Decode(c.Textual.StateMap)
+		if err != nil {
+			return nil, err
+		}
+		litem = PackUInt16(uint16(len(bytes)))
+		b = append(b, litem...)
+		b = append(b, bytes...)
+	}
+
+	cm.Textual, err = NewCtrtMetaTextualFromBytes(b)
+	if err != nil {
+		return nil, err
+	}
+
+	return cm, nil
+}
+
 func NewCtrtMeta(b []byte) (*CtrtMeta, error) {
 	langCode := CtrtMetaLangCode(b[:CTRT_META_LANG_CODE_BYTE_LEN])
 	b = b[CTRT_META_LANG_CODE_BYTE_LEN:]

--- a/vsys/model_ctrt_meta.go
+++ b/vsys/model_ctrt_meta.go
@@ -335,6 +335,8 @@ func (c *CtrtMetaJSON) GetCtrtMeta() (*CtrtMeta, error) {
 	l := 3
 	if c.LangVer == 2 {
 		l++
+	} else {
+		c.StateMap = NewEmptyCtrtMetaStateMap()
 	}
 	b := PackUInt16(uint16(l))
 
@@ -346,6 +348,7 @@ func (c *CtrtMetaJSON) GetCtrtMeta() (*CtrtMeta, error) {
 	litem := PackUInt16(uint16(len(bytes)))
 	b = append(b, litem...)
 	b = append(b, bytes...)
+
 	bytes, err = B58Decode(c.Textual.Descriptors)
 	if err != nil {
 		return nil, err
@@ -353,12 +356,15 @@ func (c *CtrtMetaJSON) GetCtrtMeta() (*CtrtMeta, error) {
 	litem = PackUInt16(uint16(len(bytes)))
 	b = append(b, litem...)
 	b = append(b, bytes...)
+
+	bytes, err = B58Decode(c.Textual.StateVars)
 	if err != nil {
 		return nil, err
 	}
 	litem = PackUInt16(uint16(len(bytes)))
 	b = append(b, litem...)
 	b = append(b, bytes...)
+	
 	if c.LangVer == 2 {
 		bytes, err = B58Decode(c.Textual.StateMap)
 		if err != nil {
@@ -373,7 +379,6 @@ func (c *CtrtMetaJSON) GetCtrtMeta() (*CtrtMeta, error) {
 	if err != nil {
 		return nil, err
 	}
-
 	return cm, nil
 }
 

--- a/vsys/model_ctrt_meta.go
+++ b/vsys/model_ctrt_meta.go
@@ -287,11 +287,11 @@ type CtrtMetaTextualJSON struct {
 }
 
 func NewCtrtMetaTextualFromBytes(b []byte) (*CtrtMetaTextual, error) {
-	_, err := NewCtrtMetaBytesListFromBytes(b, false)
+	cbl, err := NewCtrtMetaBytesListFromBytes(b, false)
 	if err != nil {
 		return nil, fmt.Errorf("NewCtrtMetaTextualFromBytes: %w", err)
 	}
-	return &CtrtMetaTextual{}, nil
+	return &CtrtMetaTextual{cbl}, nil
 }
 
 func (c *CtrtMetaTextual) Serialize() Bytes {


### PR DESCRIPTION
## What Does This PR Do
Fix constructor after fixing GetTxInfo in #38. Forgot to put in original state after experiments. 

## How Are The Changes Tested
Local scripts registering contract work.
